### PR TITLE
feat(model): added map property to model type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,8 @@ export type ObjectField = BaseField & {
 export type Model = {
   name: string;
   fields: Array<ScalarField | ObjectField>;
+  /** @see https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#map-1 */
+  map?: string;
   /** @see https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema#comments */
   documentation?: string;
 };


### PR DESCRIPTION
## Motivation
This pull request introduces the 'map' property to the Model typescript interface. This change is a preparatory step towards adding support for the  `@@map` functionality of Prisma in the main 'prisma-schema-dsl' repository. 

With the 'map' property, models in the schema can be mapped to custom database table names, enabling greater flexibility in database design.

